### PR TITLE
`tip` version optional in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ go:
   - 1.5
   - tip
 
+matrix:
+  allow_failures:
+    - go: tip
+
 install:
   - go get -d -v ./... && go build -v ./...
   - go get -u github.com/stretchr/testify/assert


### PR DESCRIPTION
`tip` version is the latest dev version and is therefor allowed to fail